### PR TITLE
11.5 compatibility by lowering version requirement

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -85,7 +85,7 @@ jobs:
       max-parallel: 2
       matrix:
         php-versions: [8.2, 8.1]
-        typo3-versions: [12]
+        typo3-versions: [11, 12]
 
     name: Functional Testing (PHP ${{ matrix.php-versions }}, TYPO3 ${{ matrix.typo3-versions }})
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -150,7 +150,7 @@ jobs:
         name: Upload coverage results to Coveralls
         uses: paambaati/codeclimate-action@v4.0.0
         env:
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+          CC_TEST_REPORTER_ID: 32807026fddd031a98d1371e6a9360c6bd30f7be0d4bb9a5516a93cd748d9b34
         with:
           coverageLocations: |
             clover.unit.xml:clover

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
 		"GPL-2.0-or-later"
 	],
 	"require": {
-		"typo3/cms-core": "^12.4"
+		"php": ">=8.1",
+		"typo3/cms-core": "^11.5 || ^12.4"
 	},
 	"require-dev": {
 		"typo3/coding-standards": "^0.7.1",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,7 +10,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.1.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-12.4.99',
+            'typo3' => '11.5.0-12.4.99',
         ],
     ],
     'autoload' => [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend;
 
+defined('TYPO3') or die();
+
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['viteassetcollector_manifest']
     ??= [];
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['viteassetcollector_manifest']['backend']


### PR DESCRIPTION
This is a simple change in composer.json lowering required version of typo3 to `^11.5 || ^12.4` 