### PR TITLE
Add option to include/exclude css assets

### DIFF
--- a/Classes/ViewHelpers/Asset/ViteViewHelper.php
+++ b/Classes/ViewHelpers/Asset/ViteViewHelper.php
@@ -42,6 +42,7 @@ final class ViteViewHelper extends AbstractViewHelper
         );
         $this->registerArgument('devTagAttributes', 'array', 'Additional attributes for dev server script tags.', false, []);
         $this->registerArgument('scriptTagAttributes', 'array', 'Additional attributes for script tags.', false, []);
+        $this->registerArgument('addCss', 'boolean', 'Define whether css assets should be included.', false, true);
         $this->registerArgument('cssTagAttributes', 'array', 'Additional attributes for css link tags.', false, []);
         $this->registerArgument(
             'priority',
@@ -74,7 +75,7 @@ final class ViteViewHelper extends AbstractViewHelper
             $this->viteService->addAssetsFromManifest(
                 $manifest,
                 $entry,
-                true,
+                $this->arguments['addCss'],
                 $assetOptions,
                 $this->arguments['scriptTagAttributes'],
                 $this->arguments['cssTagAttributes']


### PR DESCRIPTION
Hello,

I just added possibility for `asset.vite` view helper to also exclude css file being imported in case of someone (like me) want to just compile the css file, but not include it in this way.

My workflow is to include css file as inline style, that's why I needed this option.

Please review it and if you don't find it useful or have different opinion, feel free to reject the pull request.