### PR TITLE
Feature/extension config api

### DIFF
--- a/Classes/Configuration/VitePlaceholderProcessor.php
+++ b/Classes/Configuration/VitePlaceholderProcessor.php
@@ -6,7 +6,6 @@ namespace Praetorius\ViteAssetCollector\Configuration;
 
 use Praetorius\ViteAssetCollector\Exception\ViteException;
 use Praetorius\ViteAssetCollector\Service\ViteService;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Configuration\Processor\Placeholder\PlaceholderProcessorInterface;
 
 final class VitePlaceholderProcessor implements PlaceholderProcessorInterface
@@ -24,7 +23,6 @@ final class VitePlaceholderProcessor implements PlaceholderProcessorInterface
     public const PLACEHOLDER_PATTERN = '^[\'"]?([^(]*?)[\'"]?(?:\s*,\s*[\'"]?([^(]*?)[\'"]?)?$';
 
     public function __construct(
-        private readonly ExtensionConfiguration $extensionConfiguration,
         private readonly ViteService $viteService
     ) {}
 
@@ -41,7 +39,7 @@ final class VitePlaceholderProcessor implements PlaceholderProcessorInterface
         }
 
         $assetFile = $matches[1];
-        $manifest = $matches[2] ?? $this->extensionConfiguration->get('vite_asset_collector', 'defaultManifest');
+        $manifest = $matches[2] ?? $this->viteService->getDefaultManifestFile();
 
         if (!is_string($manifest) || $manifest === '') {
             throw new ViteException(

--- a/Classes/IconProvider/SvgIconProvider.php
+++ b/Classes/IconProvider/SvgIconProvider.php
@@ -8,15 +8,13 @@ use Praetorius\ViteAssetCollector\Exception\ViteException;
 use Praetorius\ViteAssetCollector\Service\ViteService;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconProvider\AbstractSvgIconProvider;
 
 class SvgIconProvider extends AbstractSvgIconProvider
 {
     public function __construct(
-        private readonly ViteService $viteService,
-        private readonly ExtensionConfiguration $extensionConfiguration
+        private readonly ViteService $viteService
     ) {}
 
     /**
@@ -39,7 +37,7 @@ class SvgIconProvider extends AbstractSvgIconProvider
     private function getManifest(string $manifest): string
     {
         if ($manifest === '') {
-            $manifest = $this->extensionConfiguration->get('vite_asset_collector', 'defaultManifest');
+            $manifest = $this->viteService->getDefaultManifestFile();
         }
 
         if (!is_string($manifest) || $manifest === '') {

--- a/Classes/ViewHelpers/Asset/ViteViewHelper.php
+++ b/Classes/ViewHelpers/Asset/ViteViewHelper.php
@@ -6,10 +6,6 @@ namespace Praetorius\ViteAssetCollector\ViewHelpers\Asset;
 
 use Praetorius\ViteAssetCollector\Exception\ViteException;
 use Praetorius\ViteAssetCollector\Service\ViteService;
-use Psr\Http\Message\UriInterface;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Core\Environment;
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -19,8 +15,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 final class ViteViewHelper extends AbstractViewHelper
 {
-    protected ExtensionConfiguration $extensionConfiguration;
-
     protected ViteService $viteService;
 
     /**
@@ -66,9 +60,9 @@ final class ViteViewHelper extends AbstractViewHelper
         $entry = $this->arguments['entry'];
         $entry ??= $this->viteService->determineEntrypointFromManifest($manifest);
 
-        if ($this->useDevServer()) {
+        if ($this->viteService->useDevServer()) {
             $this->viteService->addAssetsFromDevServer(
-                $this->getDevServerUri(),
+                $this->viteService->determineDevServer($this->renderingContext->getRequest()),
                 $entry,
                 $assetOptions,
                 $this->arguments['devTagAttributes']
@@ -88,8 +82,7 @@ final class ViteViewHelper extends AbstractViewHelper
 
     private function getManifest(): string
     {
-        $manifest = $this->arguments['manifest'];
-        $manifest ??= $this->extensionConfiguration->get('vite_asset_collector', 'defaultManifest');
+        $manifest = $this->arguments['manifest'] ?? $this->viteService->getDefaultManifestFile();
 
         if (!is_string($manifest) || $manifest === '') {
             throw new ViteException(
@@ -104,31 +97,8 @@ final class ViteViewHelper extends AbstractViewHelper
         return $manifest;
     }
 
-    private function useDevServer(): bool
-    {
-        $useDevServer = $this->extensionConfiguration->get('vite_asset_collector', 'useDevServer');
-        if ($useDevServer === 'auto') {
-            return Environment::getContext()->isDevelopment();
-        }
-        return (bool)$useDevServer;
-    }
-
-    private function getDevServerUri(): UriInterface
-    {
-        $devServerUri = $this->extensionConfiguration->get('vite_asset_collector', 'devServerUri');
-        if ($devServerUri === 'auto') {
-            return $this->viteService->determineDevServer($this->renderingContext->getRequest());
-        }
-        return new Uri($devServerUri);
-    }
-
     public function injectViteService(ViteService $viteService): void
     {
         $this->viteService = $viteService;
-    }
-
-    public function injectExtensionConfiguration(ExtensionConfiguration $extensionConfiguration): void
-    {
-        $this->extensionConfiguration = $extensionConfiguration;
     }
 }

--- a/Classes/ViewHelpers/Resource/ViteViewHelper.php
+++ b/Classes/ViewHelpers/Resource/ViteViewHelper.php
@@ -6,7 +6,6 @@ namespace Praetorius\ViteAssetCollector\ViewHelpers\Resource;
 
 use Praetorius\ViteAssetCollector\Exception\ViteException;
 use Praetorius\ViteAssetCollector\Service\ViteService;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -14,8 +13,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 final class ViteViewHelper extends AbstractViewHelper
 {
-    protected ExtensionConfiguration $extensionConfiguration;
-
     protected ViteService $viteService;
 
     public function initializeArguments(): void
@@ -43,8 +40,7 @@ final class ViteViewHelper extends AbstractViewHelper
 
     private function getManifest(): string
     {
-        $manifest = $this->arguments['manifest'];
-        $manifest ??= $this->extensionConfiguration->get('vite_asset_collector', 'defaultManifest');
+        $manifest = $this->arguments['manifest'] ?? $this->viteService->getDefaultManifestFile();
 
         if (!is_string($manifest) || $manifest === '') {
             throw new ViteException(
@@ -62,10 +58,5 @@ final class ViteViewHelper extends AbstractViewHelper
     public function injectViteService(ViteService $viteService): void
     {
         $this->viteService = $viteService;
-    }
-
-    public function injectExtensionConfiguration(ExtensionConfiguration $extensionConfiguration): void
-    {
-        $this->extensionConfiguration = $extensionConfiguration;
     }
 }

--- a/Tests/Functional/ViewHelpers/Asset/ViteViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Asset/ViteViewHelperTest.php
@@ -6,10 +6,13 @@ namespace Praetorius\ViteAssetCollector\Tests\Functional\ViewHelpers\Asset;
 
 use Praetorius\ViteAssetCollector\Exception\ViteException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Page\AssetCollector;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
+use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 final class ViteViewHelperTest extends FunctionalTestCase
 {
@@ -21,9 +24,6 @@ final class ViteViewHelperTest extends FunctionalTestCase
         'typo3conf/ext/vite_asset_collector/Tests/Fixtures' => 'fileadmin/Fixtures/',
     ];
 
-    private ?StandaloneView $view;
-    private ?AssetCollector $assetCollector;
-
     public function setUp(): void
     {
         parent::setUp();
@@ -33,19 +33,6 @@ final class ViteViewHelperTest extends FunctionalTestCase
             'devServerUri' => 'https://localhost:5173',
             'defaultManifest' => 'fileadmin/Fixtures/DefaultManifest/manifest.json',
         ]);
-
-        $this->view = GeneralUtility::makeInstance(StandaloneView::class);
-        $this->view->getViewHelperResolver()->addNamespace(
-            'vac',
-            'Praetorius\\ViteAssetCollector\\ViewHelpers'
-        );
-        $this->assetCollector = $this->get(AssetCollector::class);
-    }
-
-    public function tearDown(): void
-    {
-        $this->view = $this->assetCollector = null;
-        parent::tearDown();
     }
 
     public static function renderDataProvider(): array
@@ -198,24 +185,27 @@ final class ViteViewHelperTest extends FunctionalTestCase
         array $styleSheets,
         array $priorityStyleSheets
     ): void {
-        $this->view->setTemplateSource($template);
-        $this->view->render();
+        $assetCollector = $this->get(AssetCollector::class);
+
+        $context = $this->createRenderingContext();
+        $context->getTemplatePaths()->setTemplateSource($template);
+        (new TemplateView($context))->render();
 
         self::assertEquals(
             $javaScripts,
-            $this->assetCollector->getJavaScripts(false)
+            $assetCollector->getJavaScripts(false)
         );
         self::assertEquals(
             $priorityJavaScripts,
-            $this->assetCollector->getJavaScripts(true)
+            $assetCollector->getJavaScripts(true)
         );
         self::assertEquals(
             $styleSheets,
-            $this->assetCollector->getStyleSheets(false)
+            $assetCollector->getStyleSheets(false)
         );
         self::assertEquals(
             $priorityStyleSheets,
-            $this->assetCollector->getStyleSheets(true)
+            $assetCollector->getStyleSheets(true)
         );
     }
 
@@ -229,10 +219,11 @@ final class ViteViewHelperTest extends FunctionalTestCase
             'devServerUri' => 'https://localhost:5173',
         ]);
 
-        $this->view->setTemplateSource(
-            '<vac:asset.vite manifest="fileadmin/Fixtures/ValidManifest/manifest.json" entry="Main.js" />'
-        );
-        $this->view->render();
+        $assetCollector = $this->get(AssetCollector::class);
+
+        $context = $this->createRenderingContext();
+        $context->getTemplatePaths()->setTemplateSource('<vac:asset.vite manifest="fileadmin/Fixtures/ValidManifest/manifest.json" entry="Main.js" />');
+        (new TemplateView($context))->render();
 
         self::assertEquals(
             [
@@ -247,7 +238,7 @@ final class ViteViewHelperTest extends FunctionalTestCase
                     'options' => ['priority' => false, 'useNonce' => false],
                 ],
             ],
-            $this->assetCollector->getJavaScripts(false)
+            $assetCollector->getJavaScripts(false)
         );
     }
 
@@ -260,12 +251,21 @@ final class ViteViewHelperTest extends FunctionalTestCase
             'defaultManifest' => '',
         ]);
 
-        $this->view->setTemplateSource(
-            '<vac:asset.vite entry="Default.js" />'
-        );
+        $context = $this->createRenderingContext();
+        $context->getTemplatePaths()->setTemplateSource('<vac:asset.vite entry="Default.js" />');
 
         $this->expectException(ViteException::class);
         $this->expectExceptionCode(1684528724);
-        $this->view->render();
+        (new TemplateView($context))->render();
+    }
+
+    protected function createRenderingContext(): RenderingContextInterface
+    {
+        $context = $this->get(RenderingContextFactory::class)->create();
+        $context->getViewHelperResolver()->addNamespace('vac', 'Praetorius\\ViteAssetCollector\\ViewHelpers');
+        $context->setRequest(
+            (new ServerRequest())->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE)
+        );
+        return $context;
     }
 }

--- a/Tests/Functional/ViewHelpers/Asset/ViteViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Asset/ViteViewHelperTest.php
@@ -9,6 +9,8 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Page\AssetCollector;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -264,7 +266,12 @@ final class ViteViewHelperTest extends FunctionalTestCase
         $context = $this->get(RenderingContextFactory::class)->create();
         $context->getViewHelperResolver()->addNamespace('vac', 'Praetorius\\ViteAssetCollector\\ViewHelpers');
         $context->setRequest(
-            (new ServerRequest())->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE)
+            // TODO remove the ExtBase request when support for TYPO3 v11 is dropped
+            new Request(
+                (new ServerRequest())
+                    ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE)
+                    ->withAttribute('extbase', new ExtbaseRequestParameters())
+            )
         );
         return $context;
     }

--- a/Tests/Functional/ViewHelpers/Resource/ViteViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Resource/ViteViewHelperTest.php
@@ -8,6 +8,8 @@ use Praetorius\ViteAssetCollector\Exception\ViteException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -81,7 +83,12 @@ final class ViteViewHelperTest extends FunctionalTestCase
         $context = $this->get(RenderingContextFactory::class)->create();
         $context->getViewHelperResolver()->addNamespace('vac', 'Praetorius\\ViteAssetCollector\\ViewHelpers');
         $context->setRequest(
-            (new ServerRequest())->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE)
+            // TODO remove the ExtBase request when support for TYPO3 v11 is dropped
+            new Request(
+                (new ServerRequest())
+                    ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE)
+                    ->withAttribute('extbase', new ExtbaseRequestParameters())
+            )
         );
         return $context;
     }


### PR DESCRIPTION
It is now possible to access the default manifest file, the dev server
status flag (useDevServer) and the configured dev server uri directly
from the ViteService class, without reading them from the configuration
manually.