### PR TITLE
Feature/resource from dev server

### DIFF
--- a/Classes/Service/ViteService.php
+++ b/Classes/Service/ViteService.php
@@ -75,6 +75,14 @@ class ViteService
         );
     }
 
+    public function getAssetPathFromDevServer(
+        UriInterface $devServerUri,
+        string $assetFile,
+    ): string {
+        $assetFile = $this->determineAssetIdentifierFromExtensionPath($assetFile);
+        return (string)$devServerUri->withPath($assetFile);
+    }
+
     public function determineEntrypointFromManifest(string $manifestFile): string
     {
         $manifestFile = $this->resolveManifestFile($manifestFile);

--- a/Classes/ViewHelpers/Resource/ViteViewHelper.php
+++ b/Classes/ViewHelpers/Resource/ViteViewHelper.php
@@ -6,14 +6,20 @@ namespace Praetorius\ViteAssetCollector\ViewHelpers\Resource;
 
 use Praetorius\ViteAssetCollector\Exception\ViteException;
 use Praetorius\ViteAssetCollector\Service\ViteService;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
- * This ViewHelper extracts asset uris from a vite manifest file
+ * This ViewHelper creates an uri to a specific asset file
  */
 final class ViteViewHelper extends AbstractViewHelper
 {
     protected ViteService $viteService;
+
+    /**
+     * @var RenderingContext
+     */
+    protected $renderingContext;
 
     public function initializeArguments(): void
     {
@@ -25,13 +31,20 @@ final class ViteViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'file',
             'string',
-            'Asset file for which uri should be extracted',
+            'Asset file for which uri should be created',
             true
         );
     }
 
     public function render(): string
     {
+        if ($this->viteService->useDevServer()) {
+            return $this->viteService->getAssetPathFromDevServer(
+                $this->viteService->determineDevServer($this->renderingContext->getRequest()),
+                $this->arguments['file']
+            );
+        }
+
         return $this->viteService->getAssetPathFromManifest(
             $this->getManifest(),
             $this->arguments['file']

--- a/Tests/Functional/ViewHelpers/Resource/ViteViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Resource/ViteViewHelperTest.php
@@ -62,6 +62,23 @@ final class ViteViewHelperTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function renderWithDevServer(): void
+    {
+        $this->get(ExtensionConfiguration::class)->set('vite_asset_collector', [
+            'useDevServer' => '1',
+            'devServerUri' => 'https://localhost:5173',
+        ]);
+
+        $context = $this->createRenderingContext();
+        $context->getTemplatePaths()->setTemplateSource('<vac:resource.vite file="path/to/file.jpg" />');
+
+        self::assertEquals(
+            'https://localhost:5173/path/to/file.jpg',
+            (new TemplateView($context))->render(),
+        );
+    }
+
+    #[Test]
     public function renderWithoutManifest()
     {
         $this->get(ExtensionConfiguration::class)->set('vite_asset_collector', [

--- a/Tests/Unit/Service/ViteServiceTest.php
+++ b/Tests/Unit/Service/ViteServiceTest.php
@@ -528,6 +528,27 @@ final class ViteServiceTest extends UnitTestCase
         $this->createViteService()->addAssetsFromManifest($manifestFile, $entry);
     }
 
+    public static function getAssetPathFromDevServerDataProvider(): array
+    {
+        return [
+            ['path/to/file.jpg', 'https://localhost:5173/path/to/file.jpg'],
+            ['EXT:test_extension/Resources/Private/Assets/test.txt', 'https://localhost:5173/Tests/Fixtures/test_extension/Resources/Private/Assets/test.txt'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('getAssetPathFromDevServerDataProvider')]
+    public function getAssetPathFromDevServer(string $file, string $expected): void
+    {
+        self::assertEquals(
+            $expected,
+            $this->createViteService()->getAssetPathFromDevServer(
+                new Uri('https://localhost:5173'),
+                $file
+            )
+        );
+    }
+
     #[Test]
     public function getAssetPathFromManifest(): void
     {
@@ -596,6 +617,10 @@ final class ViteServiceTest extends UnitTestCase
                 [
                     'EXT:test_extension/Resources/Private/JavaScript/Main.js',
                     $fixtureDir . 'test_extension/Resources/Private/JavaScript/Main.js',
+                ],
+                [
+                    'EXT:test_extension/Resources/Private/Assets/test.txt',
+                    $fixtureDir . 'test_extension/Resources/Private/Assets/test.txt',
                 ],
                 [
                     'EXT:symlink_extension/Resources/Private/JavaScript/Main.js',


### PR DESCRIPTION
Previously, individual asset uris could only be resolved if there was
a valid manifest file. Now, the resource.vite ViewHelper uses the
vite dev server when it's active.

Resolves #52