### PR TITLE
Hint in docs on using glob pattern in `ViteEntrypoints.json`

### DIFF
--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -77,6 +77,8 @@ For each extension, you can define one or multiple vite entrypoints in a json fi
     ]
 
 
+It is also possible to define a glob pattern like this: `"../Resources/Private/*.entry.{js,ts}"`.
+
 Then you can use the included ViewHelper to embed your assets. If you use the default
 configuration, you only need to specify your entrypoint.
 


### PR DESCRIPTION
Adds a hint in the docs that its still possible to use a glob pattern for the entry points using the `fast-glob` package similar to the usage in older versions with the generated config templates.