### PR TITLE
[DOCS] Replace deprecated "ddev get" command

### DIFF
--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -117,7 +117,7 @@ You have several options to run the dev server:
 
         .. code-block:: sh
 
-            ddev get s2b/ddev-vite-sidecar
+            ddev add-on get s2b/ddev-vite-sidecar
             ddev restart
 
         Then you can start the server inside DDEV:


### PR DESCRIPTION
With v1.23.5 "ddev get" has been deprecated in favour of "ddev add-on get".

* https://github.com/ddev/ddev/releases/tag/v1.23.5
* https://ddev.readthedocs.io/en/stable/users/usage/commands/#add-on-get