### PR TITLE
[TASK] Add nonce metatag to TYPO3 backend as well

### DIFF
--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -9,4 +9,12 @@ return [
             ],
         ],
     ],
+    'backend' => [
+        'praetorius/vite-asset-collector/add-csp-nonce-meta-tag' => [
+            'target' => 'Praetorius\ViteAssetCollector\Middleware\AddCspNonceMetaTag',
+            'after' => [
+                'typo3/cms-backend/csp-headers',
+            ],
+        ],
+    ],
 ];


### PR DESCRIPTION
This adds the special nonce metatag to the TYPO3 backend that vite uses to inject its assets CSP-friendly when the dev server is used. Naturally, this is a security-relevant change since it fiddles with the security policies in the TYPO3 backend. However, since this is really only used if the dev server is activated in the extension configuration, this is not critical for production systems.

On the flipside it enables the usage of the Vite dev server for some backend use cases, for example in backend module templates or in preview templates for content elements.

Resolves: #82