### PR TITLE
feat: include devTagAttributes for css too

### DIFF
--- a/Classes/ViewHelpers/AssetViewHelper.php
+++ b/Classes/ViewHelpers/AssetViewHelper.php
@@ -103,6 +103,7 @@ final class AssetViewHelper extends AbstractViewHelper
                 $this->viteService->determineDevServer($this->getRequest()),
                 $entry,
                 $assetOptions,
+                $this->arguments['devTagAttributes'],
                 $this->arguments['devTagAttributes']
             );
         } else {


### PR DESCRIPTION
Added support for passing `devTagAttributes` argument during dev twice. Thus it is possible, to add media-attributes for css files in dev mode for instance.