### PR TITLE
[BUGFIX] Avoid double path preparation in icon provider

### DIFF
--- a/Classes/IconProvider/SvgIconProvider.php
+++ b/Classes/IconProvider/SvgIconProvider.php
@@ -31,7 +31,7 @@ class SvgIconProvider extends AbstractSvgIconProvider
             $options['source']
         );
 
-        return '<img src="' . htmlspecialchars($this->getPublicPath($source)) . '" width="' . $icon->getDimension()->getWidth() . '" height="' . $icon->getDimension()->getHeight() . '" alt="" />';
+        return '<img src="' . htmlspecialchars($source) . '" width="' . $icon->getDimension()->getWidth() . '" height="' . $icon->getDimension()->getHeight() . '" alt="" />';
     }
 
     private function getManifest(string $manifest): string


### PR DESCRIPTION
`getAssetPathFromManifest()` already returns a valid web path,
so it's not necessary to call `getPublicPath()` again, which would
only prepare the path once more. This also avoids mixing old TYPO3
path APIs and the new resource publishing API to be introduced with
TYPO3 v14.

At a later step, `ViteService` will be adjusted to use the new
API.