### PR TITLE
[BUGFIX] Apply type hint locally in VH to be compatible with Fluid 5

### DIFF
--- a/Classes/ViewHelpers/AssetViewHelper.php
+++ b/Classes/ViewHelpers/AssetViewHelper.php
@@ -55,11 +55,6 @@ final class AssetViewHelper extends AbstractViewHelper
 {
     protected ViteService $viteService;
 
-    /**
-     * @var RenderingContext
-     */
-    protected $renderingContext;
-
     public function initializeArguments(): void
     {
         $this->registerArgument(
@@ -143,7 +138,9 @@ final class AssetViewHelper extends AbstractViewHelper
             !method_exists($this->renderingContext, 'hasAttribute') ||
             !$this->renderingContext->hasAttribute(ServerRequestInterface::class)
         ) {
-            return $this->renderingContext->getRequest();
+            /** @var RenderingContext */
+            $renderingContext = $this->renderingContext;
+            return $renderingContext->getRequest();
         }
         return $this->renderingContext->getAttribute(ServerRequestInterface::class);
     }

--- a/Classes/ViewHelpers/UriViewHelper.php
+++ b/Classes/ViewHelpers/UriViewHelper.php
@@ -54,11 +54,6 @@ final class UriViewHelper extends AbstractViewHelper
 {
     protected ViteService $viteService;
 
-    /**
-     * @var RenderingContext
-     */
-    protected $renderingContext;
-
     public function initializeArguments(): void
     {
         $this->registerArgument(
@@ -114,7 +109,9 @@ final class UriViewHelper extends AbstractViewHelper
             !method_exists($this->renderingContext, 'hasAttribute') ||
             !$this->renderingContext->hasAttribute(ServerRequestInterface::class)
         ) {
-            return $this->renderingContext->getRequest();
+            /** @var RenderingContext */
+            $renderingContext = $this->renderingContext;
+            return $renderingContext->getRequest();
         }
         return $this->renderingContext->getAttribute(ServerRequestInterface::class);
     }


### PR DESCRIPTION
Fluid 5 adds a PHP type for `$renderingContext` in `AbstractViewHelper`, which means that ViewHelpers can't "re-declare" this property if they want to stay compatible with older TYPO3 versions. The type hint to TYPO3's rendering context, which provided `getRequest()` until TYPO3 12, is now applied locally and can be removed if compatibility for v12 is dropped.