### PR TITLE
[FEATURE] Support inlining CSS via inlineCss argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /Build/Testing/.phpunit.cache
 /Documentation-GENERATED-temp
 /fluidDocumentationOutput
+/.idea

--- a/Classes/Service/ViteService.php
+++ b/Classes/Service/ViteService.php
@@ -171,35 +171,39 @@ class ViteService
         }
 
         if ($addCss) {
+            $inlineCss = $this->shouldInlineCss($cssTagAttributes);
+            $cssTagAttributes = $this->prepareCssAttributes($cssTagAttributes);
+
             if ($entryPoint->isCss()) {
-                $this->assetCollector->addStyleSheet(
+                $this->addCssAsset(
                     "vite:{$entry}",
-                    $this->prepareAssetPath($outputDir . $entryPoint->file),
+                    $outputDir . $entryPoint->file,
                     $cssTagAttributes,
-                    $assetOptions
+                    $assetOptions,
+                    $inlineCss
                 );
             }
-
-            $cssTagAttributes = $this->prepareCssAttributes($cssTagAttributes);
 
             foreach ($manifest->getImportsForEntrypoint($entry, true) as $import) {
                 $identifier = md5($import->identifier . '|' . serialize($cssTagAttributes));
                 foreach ($import->css as $file) {
-                    $this->assetCollector->addStyleSheet(
+                    $this->addCssAsset(
                         "vite:{$identifier}:{$file}",
-                        $this->prepareAssetPath($outputDir . $file),
+                        $outputDir . $file,
                         $cssTagAttributes,
-                        $assetOptions
+                        $assetOptions,
+                        $inlineCss
                     );
                 }
             }
 
             foreach ($manifest->get($entry)->css as $file) {
-                $this->assetCollector->addStyleSheet(
+                $this->addCssAsset(
                     "vite:{$entry}:{$file}",
-                    $this->prepareAssetPath($outputDir . $file),
+                    $outputDir . $file,
                     $cssTagAttributes,
-                    $assetOptions
+                    $assetOptions,
+                    $inlineCss
                 );
             }
         }
@@ -347,9 +351,50 @@ class ViteService
 
     protected function prepareCssAttributes(array $attributes): array
     {
+        unset($attributes['inline']);
         if ($attributes['disabled'] ?? false) {
             $attributes['disabled'] = 'disabled';
         }
         return $attributes;
+    }
+
+    protected function shouldInlineCss(array $attributes): bool
+    {
+        return (bool)($attributes['inline'] ?? false);
+    }
+
+    protected function addCssAsset(
+        string $identifier,
+        string $assetPath,
+        array $attributes,
+        array $assetOptions,
+        bool $inlineCss
+    ): void {
+        if ($inlineCss) {
+            $absoluteAssetPath = GeneralUtility::getFileAbsFileName($assetPath);
+            if ($absoluteAssetPath === '' || !is_file($absoluteAssetPath)) {
+                throw new ViteException(sprintf(
+                    'CSS asset file "%s" was resolved to "%s" and cannot be opened for inline rendering.',
+                    $assetPath,
+                    $absoluteAssetPath
+                ), 1745414701);
+            }
+
+            $cssSource = (string)file_get_contents($absoluteAssetPath);
+            $this->assetCollector->addInlineStyleSheet(
+                $identifier,
+                $cssSource,
+                $attributes,
+                [...$assetOptions, 'priority' => true]
+            );
+            return;
+        }
+
+        $this->assetCollector->addStyleSheet(
+            $identifier,
+            $this->prepareAssetPath($assetPath),
+            $attributes,
+            $assetOptions
+        );
     }
 }

--- a/Classes/Service/ViteService.php
+++ b/Classes/Service/ViteService.php
@@ -167,35 +167,39 @@ class ViteService
         }
 
         if ($addCss) {
+            $inlineCss = $this->shouldInlineCss($cssTagAttributes);
+            $cssTagAttributes = $this->prepareCssAttributes($cssTagAttributes);
+
             if ($entryPoint->isCss()) {
-                $this->assetCollector->addStyleSheet(
+                $this->addCssAsset(
                     "vite:{$entry}",
-                    $this->prepareAssetPath($outputDir . $entryPoint->file, $assetOptions['external']),
+                    $outputDir . $entryPoint->file,
                     $cssTagAttributes,
-                    $assetOptions
+                    $assetOptions,
+                    $inlineCss
                 );
             }
-
-            $cssTagAttributes = $this->prepareCssAttributes($cssTagAttributes);
 
             foreach ($manifest->getImportsForEntrypoint($entry, true) as $import) {
                 $identifier = md5($import->identifier . '|' . serialize($cssTagAttributes));
                 foreach ($import->css as $file) {
-                    $this->assetCollector->addStyleSheet(
+                    $this->addCssAsset(
                         "vite:{$identifier}:{$file}",
-                        $this->prepareAssetPath($outputDir . $file, $assetOptions['external']),
+                        $outputDir . $file,
                         $cssTagAttributes,
-                        $assetOptions
+                        $assetOptions,
+                        $inlineCss
                     );
                 }
             }
 
             foreach ($manifest->get($entry)->css as $file) {
-                $this->assetCollector->addStyleSheet(
+                $this->addCssAsset(
                     "vite:{$entry}:{$file}",
-                    $this->prepareAssetPath($outputDir . $file, $assetOptions['external']),
+                    $outputDir . $file,
                     $cssTagAttributes,
-                    $assetOptions
+                    $assetOptions,
+                    $inlineCss
                 );
             }
         }
@@ -323,9 +327,50 @@ class ViteService
 
     protected function prepareCssAttributes(array $attributes): array
     {
+        unset($attributes['inline']);
         if ($attributes['disabled'] ?? false) {
             $attributes['disabled'] = 'disabled';
         }
         return $attributes;
+    }
+
+    protected function shouldInlineCss(array $attributes): bool
+    {
+        return (bool)($attributes['inline'] ?? false);
+    }
+
+    protected function addCssAsset(
+        string $identifier,
+        string $assetPath,
+        array $attributes,
+        array $assetOptions,
+        bool $inlineCss
+    ): void {
+        if ($inlineCss) {
+            $absoluteAssetPath = GeneralUtility::getFileAbsFileName($assetPath);
+            if ($absoluteAssetPath === '' || !is_file($absoluteAssetPath)) {
+                throw new ViteException(sprintf(
+                    'CSS asset file "%s" was resolved to "%s" and cannot be opened for inline rendering.',
+                    $assetPath,
+                    $absoluteAssetPath
+                ), 1745414701);
+            }
+
+            $cssSource = (string)file_get_contents($absoluteAssetPath);
+            $this->assetCollector->addInlineStyleSheet(
+                $identifier,
+                $cssSource,
+                $attributes,
+                [...$assetOptions, 'priority' => true]
+            );
+            return;
+        }
+
+        $this->assetCollector->addStyleSheet(
+            $identifier,
+            $this->prepareAssetPath($assetPath, $assetOptions['external']),
+            $attributes,
+            $assetOptions
+        );
     }
 }

--- a/Classes/Service/ViteService.php
+++ b/Classes/Service/ViteService.php
@@ -129,7 +129,8 @@ class ViteService
         bool $addCss = true,
         array $assetOptions = [],
         array $scriptTagAttributes = [],
-        array $cssTagAttributes = []
+        array $cssTagAttributes = [],
+        bool $inlineCss = false,
     ): void {
         $manifestFile = $this->resolveManifestFile($manifestFile);
         $outputDir = $this->determineOutputDirFromManifestFile($manifestFile);
@@ -171,7 +172,6 @@ class ViteService
         }
 
         if ($addCss) {
-            $inlineCss = $this->shouldInlineCss($cssTagAttributes);
             $cssTagAttributes = $this->prepareCssAttributes($cssTagAttributes);
 
             if ($entryPoint->isCss()) {
@@ -351,16 +351,10 @@ class ViteService
 
     protected function prepareCssAttributes(array $attributes): array
     {
-        unset($attributes['inline']);
         if ($attributes['disabled'] ?? false) {
             $attributes['disabled'] = 'disabled';
         }
         return $attributes;
-    }
-
-    protected function shouldInlineCss(array $attributes): bool
-    {
-        return (bool)($attributes['inline'] ?? false);
     }
 
     protected function addCssAsset(

--- a/Classes/Service/ViteService.php
+++ b/Classes/Service/ViteService.php
@@ -385,7 +385,7 @@ class ViteService
                 $identifier,
                 $cssSource,
                 $attributes,
-                [...$assetOptions, 'priority' => true]
+                $assetOptions
             );
             return;
         }

--- a/Classes/ViewHelpers/AssetViewHelper.php
+++ b/Classes/ViewHelpers/AssetViewHelper.php
@@ -73,6 +73,7 @@ final class AssetViewHelper extends AbstractViewHelper implements ViewHelperNode
         $this->registerArgument('devTagAttributes', 'array', 'HTML attributes that should be added to script tags that point to the vite dev server', false, []);
         $this->registerArgument('scriptTagAttributes', 'array', 'HTML attributes that should be added to script tags for built JavaScript assets', false, []);
         $this->registerArgument('addCss', 'boolean', 'If set to "false", CSS files associated with the entry point won\'t be added to the asset collector', false, true);
+        $this->registerArgument('inlineCss', 'boolean', 'If set to "true", CSS will be added as inline <style> tag.', false, false);
         $this->registerArgument('cssTagAttributes', 'array', 'Additional attributes for css link tags.', false, []);
         $this->registerArgument(
             'priority',
@@ -110,7 +111,8 @@ final class AssetViewHelper extends AbstractViewHelper implements ViewHelperNode
                 $this->arguments['addCss'],
                 $assetOptions,
                 $this->arguments['scriptTagAttributes'],
-                $this->arguments['cssTagAttributes']
+                $this->arguments['cssTagAttributes'],
+                $this->arguments['inlineCss'],
             );
         }
         return '';

--- a/Tests/Fixtures/ValidManifest/assets/Main-973bb662.css
+++ b/Tests/Fixtures/ValidManifest/assets/Main-973bb662.css
@@ -1,0 +1,1 @@
+.main{color:red;}

--- a/Tests/Functional/ViewHelpers/AssetViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/AssetViewHelperTest.php
@@ -139,6 +139,28 @@ final class AssetViewHelperTest extends FunctionalTestCase
                         'options' => ['priority' => false, 'useNonce' => false, 'external' => true],
                     ],
                 ],
+                'inlineStyleSheets' => [
+                    'vite:Main.js:assets/Main-973bb662.css' => [
+                        'source' => ".main{color:red;}\n",
+                        'attributes' => ['media' => 'print'],
+                        'options' => ['priority' => false, 'useNonce' => false, 'external' => true],
+                    ],
+                ],
+            ],
+            'withInlineCssAndPriority' => [
+                'template' => '<vite:asset
+                    manifest="fileadmin/Fixtures/ValidManifest/.vite/manifest.json"
+                    entry="Main.js"
+                    cssTagAttributes="{inline: 1, media: \'print\'}"
+                    priority="1"
+                />',
+                'priorityJavaScripts' => [
+                    'vite:Main.js' => [
+                        'source' => self::rawAssetUriPrefix() . $manifestDir . 'ValidManifest/assets/Main-4483b920.js',
+                        'attributes' => ['type' => 'module'],
+                        'options' => ['priority' => true, 'useNonce' => false, 'external' => true],
+                    ],
+                ],
                 'priorityInlineStyleSheets' => [
                     'vite:Main.js:assets/Main-973bb662.css' => [
                         'source' => ".main{color:red;}\n",

--- a/Tests/Functional/ViewHelpers/AssetViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/AssetViewHelperTest.php
@@ -130,7 +130,8 @@ final class AssetViewHelperTest extends FunctionalTestCase
                 'template' => '<vite:asset
                     manifest="fileadmin/Fixtures/ValidManifest/.vite/manifest.json"
                     entry="Main.js"
-                    cssTagAttributes="{inline: 1, media: \'print\'}"
+                    cssTagAttributes="{media: \'print\'}"
+                    inlineCss="1"
                 />',
                 'javaScripts' => [
                     'vite:Main.js' => [
@@ -151,7 +152,8 @@ final class AssetViewHelperTest extends FunctionalTestCase
                 'template' => '<vite:asset
                     manifest="fileadmin/Fixtures/ValidManifest/.vite/manifest.json"
                     entry="Main.js"
-                    cssTagAttributes="{inline: 1, media: \'print\'}"
+                    cssTagAttributes="{media: \'print\'}"
+                    inlineCss="1"
                     priority="1"
                 />',
                 'priorityJavaScripts' => [

--- a/Tests/Functional/ViewHelpers/AssetViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/AssetViewHelperTest.php
@@ -126,6 +126,27 @@ final class AssetViewHelperTest extends FunctionalTestCase
                     ],
                 ],
             ],
+            'withInlineCss' => [
+                'template' => '<vite:asset
+                    manifest="fileadmin/Fixtures/ValidManifest/.vite/manifest.json"
+                    entry="Main.js"
+                    cssTagAttributes="{inline: 1, media: \'print\'}"
+                />',
+                'javaScripts' => [
+                    'vite:Main.js' => [
+                        'source' => self::rawAssetUriPrefix() . $manifestDir . 'ValidManifest/assets/Main-4483b920.js',
+                        'attributes' => ['type' => 'module'],
+                        'options' => ['priority' => false, 'useNonce' => false, 'external' => true],
+                    ],
+                ],
+                'priorityInlineStyleSheets' => [
+                    'vite:Main.js:assets/Main-973bb662.css' => [
+                        'source' => ".main{color:red;}\n",
+                        'attributes' => ['media' => 'print'],
+                        'options' => ['priority' => true, 'useNonce' => false, 'external' => true],
+                    ],
+                ],
+            ],
             'withPriority' => [
                 'template' => '<vite:asset manifest="fileadmin/Fixtures/ValidManifest/.vite/manifest.json" entry="Main.js" priority="1" />',
                 'priorityJavaScripts' => [
@@ -170,7 +191,9 @@ final class AssetViewHelperTest extends FunctionalTestCase
         array $javaScripts = [],
         array $priorityJavaScripts = [],
         array $styleSheets = [],
-        array $priorityStyleSheets = []
+        array $priorityStyleSheets = [],
+        array $inlineStyleSheets = [],
+        array $priorityInlineStyleSheets = []
     ): void {
         $assetCollector = $this->get(AssetCollector::class);
 
@@ -193,6 +216,14 @@ final class AssetViewHelperTest extends FunctionalTestCase
         self::assertEquals(
             $priorityStyleSheets,
             $assetCollector->getStyleSheets(true)
+        );
+        self::assertEquals(
+            $inlineStyleSheets,
+            $assetCollector->getInlineStyleSheets(false)
+        );
+        self::assertEquals(
+            $priorityInlineStyleSheets,
+            $assetCollector->getInlineStyleSheets(true)
         );
     }
 

--- a/Tests/Functional/ViewHelpers/AssetViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/AssetViewHelperTest.php
@@ -130,6 +130,27 @@ final class AssetViewHelperTest extends FunctionalTestCase
                     ],
                 ],
             ],
+            'withInlineCss' => [
+                'template' => '<vite:asset
+                    manifest="fileadmin/Fixtures/ValidManifest/manifest.json"
+                    entry="Main.js"
+                    cssTagAttributes="{inline: 1, media: \'print\'}"
+                />',
+                'javaScripts' => [
+                    'vite:Main.js' => [
+                        'source' => $manifestDir . 'ValidManifest/assets/Main-4483b920.js',
+                        'attributes' => ['type' => 'module'],
+                        'options' => ['priority' => false, 'useNonce' => false, 'external' => self::useExternalFlag()],
+                    ],
+                ],
+                'inlineStyleSheets' => [
+                    'vite:Main.js:assets/Main-973bb662.css' => [
+                        'source' => '.main{color:red;}',
+                        'attributes' => ['media' => 'print'],
+                        'options' => ['priority' => false, 'useNonce' => false, 'external' => self::useExternalFlag()],
+                    ],
+                ],
+            ],
             'withPriority' => [
                 'template' => '<vite:asset manifest="fileadmin/Fixtures/ValidManifest/manifest.json" entry="Main.js" priority="1" />',
                 'priorityJavaScripts' => [
@@ -174,7 +195,9 @@ final class AssetViewHelperTest extends FunctionalTestCase
         array $javaScripts = [],
         array $priorityJavaScripts = [],
         array $styleSheets = [],
-        array $priorityStyleSheets = []
+        array $priorityStyleSheets = [],
+        array $inlineStyleSheets = [],
+        array $priorityInlineStyleSheets = []
     ): void {
         $assetCollector = $this->get(AssetCollector::class);
 
@@ -197,6 +220,14 @@ final class AssetViewHelperTest extends FunctionalTestCase
         self::assertEquals(
             $priorityStyleSheets,
             $assetCollector->getStyleSheets(true)
+        );
+        self::assertEquals(
+            $inlineStyleSheets,
+            $assetCollector->getInlineStyleSheets(false)
+        );
+        self::assertEquals(
+            $priorityInlineStyleSheets,
+            $assetCollector->getInlineStyleSheets(true)
         );
     }
 


### PR DESCRIPTION
Adds support for inlining CSS assets by introducing a new `inlineCss` ViewHelper argument. If the argument is set, any CSS included in the entrypoint will be inlined into the HTML document by using the `<style>` tag instead of using `<link rel="stylesheet" />`.

The `priority` flag is respected, but still refers to all assets included in the entrypoint. If only CSS should be inlined in `<head>`, that CSS needs to be split properly from JS via vite configuration.

Resolves: #124