### PR TITLE
[TASK] Deprecate symlink resolving for entrypoints

### DIFF
--- a/Classes/Service/ViteService.php
+++ b/Classes/Service/ViteService.php
@@ -282,6 +282,10 @@ class ViteService
                     $identifier
                 ), 1696238083);
             }
+            trigger_error(
+                'Accessing symlinked vite entrypoints via their original path is deprecated in EXT:vite_asset_collector and will no longer work with v2. Switch to v3 of vite-plugin-typo3 or set "resolve.preserveSymlinks" to true in your vite config.',
+                E_USER_DEPRECATED,
+            );
         }
         $relativeDirToProjectRoot = $this->stripProjectPath($dir);
         return $relativeDirToProjectRoot . $file;

--- a/Tests/Unit/Service/ViteServiceTest.php
+++ b/Tests/Unit/Service/ViteServiceTest.php
@@ -362,19 +362,6 @@ final class ViteServiceTest extends UnitTestCase
                     ],
                 ],
             ],
-            'withSymlinkedExtPath' => [
-                'manifestFile' => $fixtureDir . 'ExtPathManifest/.vite/manifest.json',
-                'entry' => 'EXT:symlink_extension/Resources/Private/JavaScript/Main.js',
-                'options' => [],
-                'addCss' => false,
-                'javaScripts' => [
-                    'vite:Tests/Fixtures/test_extension/Resources/Private/JavaScript/Main.js' => [
-                        'source' => self::rawAssetUriPrefix() . $fixtureDir . 'ExtPathManifest/assets/Main-4483b920.js',
-                        'attributes' => ['type' => 'module', 'async' => 'async', 'otherAttribute' => 'otherValue'],
-                        'options' => ['external' => true],
-                    ],
-                ],
-            ],
             'withImportedJs' => [
                 'manifestFile' => $fixtureDir . 'ImportJs/.vite/manifest.json',
                 'entry' => 'Main.js',
@@ -480,6 +467,19 @@ final class ViteServiceTest extends UnitTestCase
     {
         $fixtureDir = realpath(__DIR__ . '/../../Fixtures') . '/';
         return [
+            'withSymlinkedExtPath' => [
+                'manifestFile' => $fixtureDir . 'ExtPathManifest/.vite/manifest.json',
+                'entry' => 'EXT:symlink_extension/Resources/Private/JavaScript/Main.js',
+                'options' => [],
+                'addCss' => false,
+                'javaScripts' => [
+                    'vite:Tests/Fixtures/test_extension/Resources/Private/JavaScript/Main.js' => [
+                        'source' => self::rawAssetUriPrefix() . $fixtureDir . 'ExtPathManifest/assets/Main-4483b920.js',
+                        'attributes' => ['type' => 'module', 'async' => 'async', 'otherAttribute' => 'otherValue'],
+                        'options' => ['external' => true],
+                    ],
+                ],
+            ],
             'vite4' => [
                 'manifestFile' => $fixtureDir . 'Vite4Manifest/manifest.json',
                 'entry' => 'Default.js',
@@ -695,6 +695,21 @@ final class ViteServiceTest extends UnitTestCase
             $manifestDir . 'assets/Main-4483b920.js',
             $this->createViteService()->getAssetPathFromManifest(
                 $fixtureDir . 'ExtPathManifest/.vite/manifest.json',
+                'EXT:test_extension/Resources/Private/JavaScript/Main.js'
+            )
+        );
+    }
+
+    #[Test]
+    #[IgnoreDeprecations]
+    public function getAssetWithSymlinkedExtPathFromManifest(): void
+    {
+        $fixtureDir = realpath(__DIR__ . '/../../Fixtures') . '/';
+        $manifestDir = realpath(__DIR__ . '/../../Fixtures/ExtPathManifest') . '/';
+        self::assertEquals(
+            $manifestDir . 'assets/Main-4483b920.js',
+            $this->createViteService()->getAssetPathFromManifest(
+                $fixtureDir . 'ExtPathManifest/.vite/manifest.json',
                 'EXT:symlink_extension/Resources/Private/JavaScript/Main.js'
             )
         );
@@ -748,6 +763,7 @@ final class ViteServiceTest extends UnitTestCase
                     'EXT:test_extension/Resources/Private/Assets/test.txt',
                     $fixtureDir . 'test_extension/Resources/Private/Assets/test.txt',
                 ],
+                // TODO remove when support for symlinks is dropped with v2
                 [
                     'EXT:symlink_extension/Resources/Private/JavaScript/Main.js',
                     $fixtureDir . 'symlink_extension/Resources/Private/JavaScript/Main.js',


### PR DESCRIPTION
With previous iterations of the client-side vite setup, it was necessary
for the TYPO3 extension to resolve symlinks to their original location
in order to generate the matching identifiers for vite's `manifest.json`.
This lead to various problems related to the usage of `realpath()`,
especially in combination with `open_basedir` server configurations.

Since `vite-plugin-typo3` v3, `resolve.preserveSymlinks` is used
to retain the original paths in the `manifest.json`. This makes
server-side symlink resolving obsolete and also doesn't require the
source asset files being present on production setups. For custom
vite setups, the flag can be specified manually in `vite.config.js`.

For v1, a fallback is in place in case symlink resolving is still
necessary. This fallback is now deprecated and will be removed with v2.

Path example:

`EXT:sitepackage/Resources/Private/Main.js` resolves to either
`vendor/myvendor/sitepackage/...` or `typo3conf/ext/sitepackage/...`
using TYPO3's path APIs. These are typically symlinks pointing to
`packages/sitepackage/...`, created by composer, however TYPO3 is not
aware of that and doesn't resolve them by default.

On the vite site, without the flag being set, `manifest.json` resolves
asset paths to their origin `packages/sitepackage/...`, following the
symlink. To access these assets from TYPO3, `realpath()` needed to be
used to resolve the symlink server-side as well to get matching paths.

With the flag being set, `manifest.json` contains the original symlink,
again either `vendor/myvendor/sitepackage/...` or
`typo3conf/ext/sitepackage/...`. This means that server-side symlink
resolving is no longer necessary.

Related change in vite-plugin-typo3:
https://github.com/s2b/vite-plugin-typo3/pull/35